### PR TITLE
Improve docs and add NatSpec

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# RPC endpoint for Ethereum mainnet
+MAINNET_RPC_URL=
+# RPC endpoint for Sepolia or other testnet
+SEPOLIA_RPC_URL=
+# Private key of the deployer account
+PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -1,19 +1,60 @@
-# Sample Hardhat Project
+# YAFM Hardhat Project
 
-This project demonstrates a basic Hardhat use case. It comes with a sample contract, a test for that contract, and a Hardhat Ignition module that deploys that contract.
+This repository contains the YAFMToken ERC20 and BadgeNFT ERC721 contracts built with [Hardhat](https://hardhat.org/).
 
-Try running some of the following tasks:
+## Requirements
 
-```shell
-npx hardhat help
-npx hardhat test
-REPORT_GAS=true npx hardhat test
-npx hardhat node
-npx hardhat ignition deploy ./ignition/modules/Lock.ts
+- Node.js 18 or higher
+- npm
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
 ```
+
+2. Copy the example environment file and populate the variables:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and provide RPC endpoints and the private key of the deployer account.
+
+3. Run the test suite to make sure everything is working:
+
+```bash
+npx hardhat test
+```
+
+## Deployment
+
+### Local development network
+
+Start a local node and deploy the contracts:
+
+```bash
+npx hardhat node
+npx hardhat run scripts/deploy.ts --network localhost
+```
+
+### Testnet/Mainnet
+
+With your `.env` configured, deploy to a public network:
+
+```bash
+# Deploy to Sepolia (or your configured testnet)
+npx hardhat run scripts/deploy.ts --network sepolia
+
+# Deploy to mainnet
+npx hardhat run scripts/deploy.ts --network mainnet
+```
+
+The deployed contract addresses will be shown in the console after each deployment.
 
 ## Deployed Contracts (Local)
 
-- **YAFMToken**: 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9  
-- **BadgeNFT**:  0x5FC8d32690cc91D4c39d9d3abcBD16989F875707  
-
+- **YAFMToken**: 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
+- **BadgeNFT**:  0x5FC8d32690cc91D4c39d9d3abcBD16989F875707

--- a/contracts/BadgeNFT.sol
+++ b/contracts/BadgeNFT.sol
@@ -1,37 +1,60 @@
-﻿ // SPDX-License-Identifier: MIT
+ // SPDX-License-Identifier: MIT
  pragma solidity ^0.8.23;
- import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
- import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 
- contract BadgeNFT is ERC721 {
-     using Strings for uint256;
-     error NonTransferable();
-     address public issuer;
-     uint256 public nextId;
-     mapping(uint256 => uint16) public lessonOf;
-     string public baseURI;
+/// @title BadgeNFT
+/// @notice Non-transferable ERC721 used to award course badges.
+/// @dev Only the `issuer` address may mint new tokens.
+contract BadgeNFT is ERC721 {
+    using Strings for uint256;
 
-     constructor(address _issuer, string memory _base) ERC721("YAFM Badge", "YBADGE") {
-         issuer = _issuer;
-         baseURI = _base;
-     }
+    /// @notice Error thrown when a transfer is attempted.
+    error NonTransferable();
 
-     function mint(address to, uint16 lessonId) external returns (uint256 id) {
-         require(msg.sender == issuer, "NOT_ISSUER");
-         id = ++nextId;
-         _safeMint(to, id);
-         lessonOf[id] = lessonId;
-     }
+    /// @notice Address allowed to mint new badges.
+    address public issuer;
 
-     function _beforeTokenTransfer(address from, address to, uint256 tokenId, uint256 batchSize)
-         internal
-         override
-     {
-         if (from != address(0) && to != address(0)) revert NonTransferable();
-         super._beforeTokenTransfer(from, to, tokenId, batchSize);
-     }
+    /// @notice Token ID that will be assigned to the next minted badge.
+    uint256 public nextId;
 
-     function tokenURI(uint256 tokenId) public view override returns (string memory) {
-         return string(abi.encodePacked(baseURI, tokenId.toString(), ".json"));
-     }
- }
+    /// @notice Lesson identifier for each badge.
+    mapping(uint256 => uint16) public lessonOf;
+
+    /// @notice Base URI used to build `tokenURI` responses.
+    string public baseURI;
+
+    /// @param _issuer Address authorized to mint badges.
+    /// @param _base Base URI for token metadata.
+    constructor(address _issuer, string memory _base) ERC721("YAFM Badge", "YBADGE") {
+        issuer = _issuer;
+        baseURI = _base;
+    }
+
+    /// @notice Mint a badge for a lesson and assign it to `to`.
+    /// @param to Recipient of the newly minted badge.
+    /// @param lessonId Identifier of the completed lesson.
+    /// @return id Newly minted token ID.
+    function mint(address to, uint16 lessonId) external returns (uint256 id) {
+        require(msg.sender == issuer, "NOT_ISSUER");
+        id = ++nextId;
+        _safeMint(to, id);
+        lessonOf[id] = lessonId;
+    }
+
+    /// @dev Prevent tokens from being transferred once minted.
+    function _update(address to, uint256 tokenId, address auth)
+        internal
+        override
+        returns (address from)
+    {
+        from = _ownerOf(tokenId);
+        if (from != address(0) && to != address(0)) revert NonTransferable();
+        return super._update(to, tokenId, auth);
+    }
+
+    /// @notice Return the metadata URI for `tokenId`.
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        return string(abi.encodePacked(baseURI, tokenId.toString(), ".json"));
+    }
+}

--- a/contracts/YAFMToken.sol
+++ b/contracts/YAFMToken.sol
@@ -1,10 +1,16 @@
-﻿ // SPDX-License-Identifier: MIT
+ // SPDX-License-Identifier: MIT
  pragma solidity ^0.8.23;
- import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
- contract YAFMToken is ERC20 {
-     uint256 public constant MAX_SUPPLY = 1_000_000_000 * 1e18;
-     constructor(address distribution) ERC20("YAFM Token", "YAFM") {
-         _mint(distribution, MAX_SUPPLY);
-     }
- }
+/// @title YAFMToken
+/// @notice ERC20 token with a fixed supply minted at deployment.
+/// @dev Entire `MAX_SUPPLY` is minted to the `distribution` address in the constructor.
+contract YAFMToken is ERC20 {
+    /// @notice Total number of tokens that will ever exist.
+    uint256 public constant MAX_SUPPLY = 1_000_000_000 * 1e18;
+
+    /// @param distribution Address that receives the full token supply.
+    constructor(address distribution) ERC20("YAFM Token", "YAFM") {
+        _mint(distribution, MAX_SUPPLY);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,8 +1,25 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+const { PRIVATE_KEY, MAINNET_RPC_URL, SEPOLIA_RPC_URL } = process.env;
+
+const accounts = PRIVATE_KEY ? [PRIVATE_KEY] : [];
 
 const config: HardhatUserConfig = {
   solidity: "0.8.28",
+  networks: {
+    sepolia: {
+      url: SEPOLIA_RPC_URL || "",
+      accounts,
+    },
+    mainnet: {
+      url: MAINNET_RPC_URL || "",
+      accounts,
+    },
+  },
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^6.1.0",
+        "@openzeppelin/contracts": "^5.4.0",
         "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.1.0",
@@ -1214,6 +1215,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.4.0.tgz",
+      "integrity": "sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
+    "@openzeppelin/contracts": "^5.4.0",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.1.0",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,0 +1,21 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Deploying contracts with:", deployer.address);
+
+  const Token = await ethers.getContractFactory("YAFMToken");
+  const token = await Token.deploy(deployer.address);
+  await token.waitForDeployment();
+  console.log("YAFMToken deployed to:", await token.getAddress());
+
+  const Badge = await ethers.getContractFactory("BadgeNFT");
+  const badge = await Badge.deploy(deployer.address, "https://example.com/");
+  await badge.waitForDeployment();
+  console.log("BadgeNFT deployed to:", await badge.getAddress());
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- document setup, environment variables, deployment, and testing
- show example environment file
- add NatSpec comments to YAFMToken and BadgeNFT
- update hardhat config for env based networks
- add deploy script for contracts
- add OpenZeppelin dependency
- fix BadgeNFT hook for OpenZeppelin v5

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68824f7fc3688331b4e02c547a7a17de